### PR TITLE
Make the description longer to comply with dart file conventions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: wolt_responsive_layout_grid
-description: Build responsive grid layouts with ease.
+description: Wolt Responsive Layout Grid library helps you to build responsive grid layouts with ease.
 version: 0.0.1
 repository: https://github.com/woltapp/wolt_responsive_layout_grid
 


### PR DESCRIPTION
To increase our pub.dev point and comply with dart file conventions, made the description longer.

![image (3)](https://github.com/woltapp/wolt_responsive_layout_grid/assets/7239330/9ed3191e-ab06-4f93-b226-574955487a41)